### PR TITLE
Create tests for replace_subgraph and the remove barrier pass

### DIFF
--- a/src/torch_onnx_models/components/_activations.py
+++ b/src/torch_onnx_models/components/_activations.py
@@ -85,6 +85,11 @@ class QuickGELUActivation(nn.Module):
         return quick_gelu(input)
 
 
+class MsftQuickGELUActivation(nn.Module):
+    def forward(self, input: Tensor) -> Tensor:
+        return quick_gelu_msft(input)
+
+
 class ClippedGELUActivation(nn.Module):
     """
     Clip the range of possible GeLU outputs between [min, max]. This is especially useful for quantization purpose, as

--- a/src/torch_onnx_models/onnx_passes/__init__.py
+++ b/src/torch_onnx_models/onnx_passes/__init__.py
@@ -1,3 +1,11 @@
-__all__ = ["AssignNamesPass"]
+__all__ = [
+    "AssignNamesPass",
+    "RemoveBarrierPass",
+    "CollectOpsetsPass",
+    "replace_subgraph",
+]
 
 from ._assign_names import AssignNamesPass
+from ._barrier_removal import RemoveBarrierPass
+from ._collect_opsets import CollectOpsetsPass
+from ._subgraph_replacement import replace_subgraph

--- a/src/torch_onnx_models/onnx_passes/_barrier_removal.py
+++ b/src/torch_onnx_models/onnx_passes/_barrier_removal.py
@@ -29,6 +29,9 @@ def _pop_node(node: ir.Node) -> None:
                 assert replacement_output is not None
                 graph.outputs[idx] = replacement_output
 
+                # Maintain the name of the graph output
+                replacement_output.name = graph_output.name
+
     # Finally remove the node
     graph.remove(node, safe=True)
 

--- a/test/barrier_test.py
+++ b/test/barrier_test.py
@@ -65,7 +65,6 @@ class BarrierTest(unittest.TestCase):
         model = _activations.QuickGELUActivation()
         x = torch.randn(2, 3)
         onnx_program = torch.onnx.export(model, (x,), dynamo=True, verbose=False)
-        print(onnx_program.model)
         barrier_node = next(
             node for node in onnx_program.model.graph if node.op_type == "Barrier"
         )

--- a/test/onnx_passes_test.py
+++ b/test/onnx_passes_test.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import unittest
 
 import torch
+
 from torch_onnx_models import onnx_passes
+from torch_onnx_models.components._activations import (
+    MsftQuickGELUActivation,
+    QuickGELUActivation,
+)
 from torch_onnx_models.components._rms_norm import RMSNorm
 
 
@@ -12,7 +17,7 @@ class AssignNamesPassTest(unittest.TestCase):
         class Model(torch.nn.Module):
             def __init__(self, hidden_size: int):
                 super().__init__()
-                self.rms_norm = RMSNorm(hidden_size=hidden_size, mode="onnx")
+                self.rms_norm = RMSNorm(hidden_size=hidden_size)
 
             def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
                 return self.rms_norm(hidden_states)
@@ -35,6 +40,44 @@ class AssignNamesPassTest(unittest.TestCase):
         pass_result = onnx_passes.AssignNamesPass()(onnx_program.model)
         print(pass_result.model)
         # TODO: Actually assert some things
+
+
+class RemoveBarrierPassTest(unittest.TestCase):
+    def test_pass(self):
+        x = torch.randn(2, 3)
+        onnx_program = torch.onnx.export(
+            QuickGELUActivation(), (x,), dynamo=True, verbose=False
+        )
+        model = onnx_program.model
+        self.assertIn("Barrier", [node.op_type for node in model.graph])
+        onnx_passes.RemoveBarrierPass()(model)
+        self.assertEqual(len(model.graph), 3)
+        self.assertNotIn("Barrier", [node.op_type for node in model.graph])
+
+
+class SubgraphReplacementTest(unittest.TestCase):
+    def test_pass(self):
+        x = torch.randn(2, 3)
+        model = torch.onnx.export(
+            QuickGELUActivation(), (x,), dynamo=True, verbose=False
+        ).model
+        ort_model = torch.onnx.export(
+            MsftQuickGELUActivation(), (x,), dynamo=True, verbose=False
+        ).model
+        region_start = next(node for node in model.graph if node.op_type == "Barrier")
+        region_end = next(
+            node for node in reversed(model.graph) if node.op_type == "Barrier"
+        )
+        self.assertNotIn("QuickGelu", [node.op_type for node in model.graph])
+        onnx_passes.replace_subgraph(
+            model, region_start.inputs, region_end.outputs, ort_model.graph
+        )
+        self.assertIn("QuickGelu", [node.op_type for node in model.graph])
+        print(model)
+
+        onnx_passes.RemoveBarrierPass()(model)
+        self.assertEqual(len(model.graph), 1)
+        print(model)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the ONNX passes and activation components, along with corresponding tests. The main changes include adding new ONNX passes, extending activation modules, and improving test coverage for these features.

### ONNX Passes Enhancements

* Added new ONNX passes: `RemoveBarrierPass`, `CollectOpsetsPass`, and the `replace_subgraph` utility, making them available for import and use. (`src/torch_onnx_models/onnx_passes/__init__.py`)
* Ensured that when removing a barrier node, the replacement output maintains the original graph output's name for consistency. (`src/torch_onnx_models/onnx_passes/_barrier_removal.py`)

### Activation Components

* Introduced a new activation module, `MsftQuickGELUActivation`, which uses the `quick_gelu_msft` function. (`src/torch_onnx_models/components/_activations.py`)

### Test Improvements

* Added tests for the new ONNX passes, including `RemoveBarrierPass` and subgraph replacement, to validate their correct behavior. (`test/onnx_passes_test.py`)
* Updated imports and test setup to include the new activation and ONNX pass modules. (`test/onnx_passes_test.py`)