### PR TITLE
Enable default rope models

### DIFF
--- a/examples/export_llama.py
+++ b/examples/export_llama.py
@@ -1,7 +1,14 @@
 from torch_onnx_models._exporter import convert_hf_model
 
-onnx_program = convert_hf_model("meta-llama/Llama-3.2-1B-Instruct", load_weights=True)
-# TODO: Show progress bar
-print("Saving ONNX model to llama-3_2-1b.onnx...")
-onnx_program.save("llama-3_2-1b.onnx", external_data=True)
+models = {
+    "llama-3_2-1b": "meta-llama/Llama-3.2-1B-Instruct",
+    # "llama-2-7b": "meta-llama/Llama-2-7b-chat-hf",
+}
+
+for name, model_id in models.items():
+    print(f"Exporting {model_id} to ONNX...")
+    onnx_program = convert_hf_model(model_id, load_weights=True)
+    # TODO: Show progress bar
+    print(f"Saving ONNX model to {name}.onnx...")
+    onnx_program.save(f"{name}.onnx", external_data=True)
 print("Done!")

--- a/src/torch_onnx_models/components/__init__.py
+++ b/src/torch_onnx_models/components/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     "create_attention_bias",
     "get_activation",
     "get_rotary_pos_emb",
+    "initialize_rope",
     "MLP",
     "RMSNorm",
 ]
@@ -13,4 +14,5 @@ from torch_onnx_models.components._attention_utils import create_attention_bias
 from torch_onnx_models.components._activations import get_activation
 from torch_onnx_models.components._rms_norm import RMSNorm
 from torch_onnx_models.components._rotary_embedding_utils import apply_rotary_pos_emb, get_rotary_pos_emb
+from torch_onnx_models.components._rotary_embedding import initialize_rope
 from torch_onnx_models.components._mlp import MLP

--- a/src/torch_onnx_models/components/_rms_norm.py
+++ b/src/torch_onnx_models/components/_rms_norm.py
@@ -16,3 +16,6 @@ class RMSNorm(nn.Module):
 
     def forward(self, hidden_states):
         return apply_rms_norm(x=hidden_states, weight=self.weight, eps=self.variance_epsilon)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"

--- a/src/torch_onnx_models/components/_rotary_embedding.py
+++ b/src/torch_onnx_models/components/_rotary_embedding.py
@@ -9,12 +9,43 @@ from torch_onnx_models import _configs
 from torch_onnx_models.components._rotary_embedding_utils import get_rotary_pos_emb
 
 
-class Llama3Rope(nn.Module):
+def _get_default_inv_freq(config: _configs.ArchitectureConfig) -> torch.Tensor:
+    return 1.0 / (config.rope_theta ** (torch.arange(0, config.head_dim, 2, dtype=torch.float) / config.head_dim))
+
+
+def _get_cos_sin_cache(max_position_embeddings: int, inv_freq: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    # should we do max position embeddings or original max position embeddings?
+    # some models like llama4 has 10 million
+    pos = torch.arange(0, max_position_embeddings, dtype=torch.float)
+    angles = torch.outer(pos, inv_freq)
+    # probably need to cast the caches to the same dtype as the model
+    return torch.cos(angles), torch.sin(angles)
+
+
+class BaseRope(nn.Module):
+    def _register_cos_sin_cache(self, cos: torch.Tensor, sin: torch.Tensor):
+        self.register_buffer("cos_cache", cos, persistent=False)
+        self.register_buffer("sin_cache", sin, persistent=False)
+
+    def forward(self, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        return get_rotary_pos_emb(position_ids, self.cos_cache, self.sin_cache)
+
+
+class DefaultRope(BaseRope):
     def __init__(self, config: _configs.ArchitectureConfig):
         super().__init__()
 
         with torch._subclasses.fake_tensor.unset_fake_temporarily():
-            inv_freq = 1.0 / (config.rope_theta ** (torch.arange(0, config.head_dim, 2, dtype=torch.float) / config.head_dim))
+            inv_freq = _get_default_inv_freq(config)
+            cos_cache, sin_cache = _get_cos_sin_cache(config.max_position_embeddings, inv_freq)
+            self._register_cos_sin_cache(cos_cache, sin_cache)
+
+class Llama3Rope(BaseRope):
+    def __init__(self, config: _configs.ArchitectureConfig):
+        super().__init__()
+
+        with torch._subclasses.fake_tensor.unset_fake_temporarily():
+            inv_freq = _get_default_inv_freq(config)
 
             # https://github.com/huggingface/transformers/blob/9f2d5666f8fda5b647e5f64dfc8ba1edd7a87a1e/src/transformers/modeling_rope_utils.py#L497
             factor = config.rope_scaling["factor"]
@@ -35,20 +66,13 @@ class Llama3Rope(nn.Module):
             is_medium_freq = ~(wavelen < high_freq_wavelen) * ~(wavelen > low_freq_wavelen)
             inv_freq_llama = torch.where(is_medium_freq, smoothed_inv_freq, inv_freq_llama)
 
-            # should we do max position embeddings or original max position embeddings?
-            # some models like llama4 has 10 million
-            pos = torch.arange(old_context_len, dtype=torch.float)
-            angles = torch.outer(pos, inv_freq_llama)
+            cos_cache, sin_cache = _get_cos_sin_cache(config.max_position_embeddings, inv_freq_llama)
+            self._register_cos_sin_cache(cos_cache, sin_cache)
 
-            # probably need to cast the caches to the same dtype as the model
-            # get it from the config?
-            self.register_buffer("cos_cache", torch.cos(angles), persistent=False)
-            self.register_buffer("sin_cache", torch.sin(angles), persistent=False)
-
-    def forward(self, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        return get_rotary_pos_emb(position_ids, self.cos_cache, self.sin_cache)
 
 def initialize_rope(config: _configs.ArchitectureConfig) -> nn.Module:
+    if config.rope_type == "default":
+        return DefaultRope(config)
     if config.rope_type == "llama3":
         return Llama3Rope(config)
 


### PR DESCRIPTION
- DefaultRope is implemented with some shared utils
- llama-2 also work now
- next step towards supporting gemma text model. next step is to support sliding window attention.

Example generation from llama-2-7b-chat-hf
<img width="1348" height="231" alt="image" src="https://github.com/user-attachments/assets/1e4b3340-bb81-4b45-9e89-16d1a9d8e792" />
