### PR TITLE
Enable mistral

### DIFF
--- a/examples/export_llama.py
+++ b/examples/export_llama.py
@@ -3,6 +3,7 @@ from torch_onnx_models._exporter import convert_hf_model
 models = {
     "llama-3_2-1b": "meta-llama/Llama-3.2-1B-Instruct",
     # "llama-2-7b": "meta-llama/Llama-2-7b-chat-hf",
+    # "mistral-7b": "mistralai/Mistral-7B-Instruct-v0.3",
 }
 
 for name, model_id in models.items():

--- a/src/torch_onnx_models/_configs.py
+++ b/src/torch_onnx_models/_configs.py
@@ -14,7 +14,7 @@ SUPPORTED_ARCHITECTURES = {
     # "gptoss",
     # "granite",
     "llama",
-    # "mistral",
+    "mistral",
     # "nemotron",
     # "olmo",
     # "phi",


### PR DESCRIPTION
Mistral is automatically supported as well now that we have default rope. 

Example generation from mistral-7b-instruct-v0.3:
<img width="1620" height="230" alt="image" src="https://github.com/user-attachments/assets/0d375ca5-6568-43ac-9ae7-46a5f20172ce" />
