### PR TITLE
Enable gemma3_text

### DIFF
--- a/examples/export_llama.py
+++ b/examples/export_llama.py
@@ -4,6 +4,7 @@ models = {
     "llama-3_2-1b": "meta-llama/Llama-3.2-1B-Instruct",
     # "llama-2-7b": "meta-llama/Llama-2-7b-chat-hf",
     # "mistral-7b": "mistralai/Mistral-7B-Instruct-v0.3",
+    # "gemma-3-1b": "google/gemma-3-1b-it",
 }
 
 for name, model_id in models.items():

--- a/src/torch_onnx_models/_configs.py
+++ b/src/torch_onnx_models/_configs.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 
-import torch
-
 # https://github.com/huggingface/transformers/blob/3e975acc8bf6d029ec0a54b1c5d0691489dfb051/src/transformers/models/auto/configuration_auto.py#L36
 SUPPORTED_ARCHITECTURES = {
     # "ernie4_5",

--- a/src/torch_onnx_models/_configs.py
+++ b/src/torch_onnx_models/_configs.py
@@ -4,13 +4,13 @@ import dataclasses
 
 import torch
 
-
 # https://github.com/huggingface/transformers/blob/3e975acc8bf6d029ec0a54b1c5d0691489dfb051/src/transformers/models/auto/configuration_auto.py#L36
 SUPPORTED_ARCHITECTURES = {
     # "ernie4_5",
     # "gemma",
     # "gemma2",
     # "gemma3",
+    "gemma3_text",
     # "gptoss",
     # "granite",
     "llama",
@@ -44,13 +44,21 @@ class ArchitectureConfig:
     num_key_value_heads: int = DEFAULT_INT
     hidden_act: str | None = None
 
+    # attention config
+    use_qk_norm: bool = False  # only for Gemma-3
+    layer_types: list[str] | None = None  # only for Gemma-3
+    sliding_window: int | None = None  # only for Gemma-3
+
     rms_norm_eps: float = 1e-6
+    rms_norm_all_fp32: bool = False  # only for Gemma-3
+    rms_norm_offset: float | None = None  # only for Gemma-3
 
     # Rotary embedding config
     rope_type: str = "default"
     rope_theta: float = 10_000.0
     rope_scaling: dict | None = None
     partial_rotary_factor: float = 1.0  # 1.0 means no partial RoPE
+    rope_local_base_freq: float | None = None  # only for Gemma-3
 
     attention_bias: bool = False
     mlp_bias: bool = False
@@ -67,27 +75,45 @@ class ArchitectureConfig:
             )
 
         options = dict(
-            head_dim=config.hidden_size // config.num_attention_heads,
-            num_attention_heads=config.num_attention_heads,
-            num_key_value_heads=(
-                getattr(config, "num_key_value_heads", config.num_attention_heads)
+            head_dim=(
+                config.head_dim
+                if (hasattr(config, "head_dim") and config.head_dim is not None)
+                else config.hidden_size // config.num_attention_heads
             ),
+            num_attention_heads=config.num_attention_heads,
+            num_key_value_heads=(getattr(config, "num_key_value_heads", config.num_attention_heads)),
             num_hidden_layers=config.num_hidden_layers,
             vocab_size=config.vocab_size,
             hidden_size=config.hidden_size,
-            intermediate_size=(
-                getattr(config, "intermediate_size", 4 * config.hidden_size)
+            intermediate_size=(getattr(config, "intermediate_size", 4 * config.hidden_size)),
+            hidden_act=(getattr(config, "hidden_act", None) or getattr(config, "hidden_activation", None)),
+            use_qk_norm=(config.model_type == "gemma3_text"),
+            # consider using the layer types directly from the hf config
+            layer_types=(
+                [
+                    "local" if (i + 1) % config.sliding_window_pattern != 0 else "global"
+                    for i in range(config.num_hidden_layers)
+                ]
+                if hasattr(config, "sliding_window_pattern")
+                else None
             ),
-            hidden_act=(getattr(config, "hidden_act", None)),
+            sliding_window=(getattr(config, "sliding_window", None)),
             pad_token_id=(getattr(config, "pad_token_id", 0)),  # FIXME
             rms_norm_eps=(getattr(config, "rms_norm_eps", 1e-6)),
+            rms_norm_all_fp32=(config.model_type == "gemma3_text"),
+            rms_norm_offset=(1.0 if config.model_type == "gemma3_text" else None),
             attention_bias=(getattr(config, "add_bias_kv", False)),
             mlp_bias=(getattr(config, "use_mlp_bias", False)),
             # how much older transformers versions are we supporting?
-            rope_type=(config.rope_scaling.get("rope_type") if hasattr(config, "rope_scaling") and isinstance(config.rope_scaling, dict) else "default"),
+            rope_type=(
+                config.rope_scaling.get("rope_type")
+                if hasattr(config, "rope_scaling") and isinstance(config.rope_scaling, dict)
+                else "default"
+            ),
             rope_theta=(getattr(config, "rope_theta", 10_000.0)),
             rope_scaling=(getattr(config, "rope_scaling", None)),
             partial_rotary_factor=(getattr(config, "partial_rotary_factor", 1.0)),
+            rope_local_base_freq=(getattr(config, "rope_local_base_freq", None)),
             max_position_embeddings=config.max_position_embeddings,
         )
 

--- a/src/torch_onnx_models/components/__init__.py
+++ b/src/torch_onnx_models/components/__init__.py
@@ -1,6 +1,8 @@
 __all__ = [
+    "apply_rms_norm",
     "apply_rotary_pos_emb",
     "Attention",
+    "CausalLMModel",
     "create_attention_bias",
     "get_activation",
     "get_rotary_pos_emb",
@@ -12,10 +14,12 @@ __all__ = [
 from torch_onnx_models.components._attention import Attention
 from torch_onnx_models.components._attention_utils import create_attention_bias
 from torch_onnx_models.components._activations import get_activation
+from torch_onnx_models.components._mlp import MLP
+from torch_onnx_models.components._model import CausalLMModel
+from torch_onnx_models.components._rms_norm_utils import apply_rms_norm
 from torch_onnx_models.components._rms_norm import RMSNorm
 from torch_onnx_models.components._rotary_embedding_utils import (
     apply_rotary_pos_emb,
     get_rotary_pos_emb,
 )
 from torch_onnx_models.components._rotary_embedding import initialize_rope
-from torch_onnx_models.components._mlp import MLP

--- a/src/torch_onnx_models/components/_decoder.py
+++ b/src/torch_onnx_models/components/_decoder.py
@@ -17,10 +17,8 @@ class DecoderLayer(nn.Module):
         self.hidden_size = config.hidden_size
         self.self_attn = Attention(config)
         self.mlp = MLP(config)
-        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.post_attention_layernorm = RMSNorm(
-            config.hidden_size, eps=config.rms_norm_eps
-        )
+        self.input_layernorm = RMSNorm(config.hidden_size, config)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, config)
 
     def forward(
         self,

--- a/src/torch_onnx_models/components/_model.py
+++ b/src/torch_onnx_models/components/_model.py
@@ -14,13 +14,9 @@ class TextModel(nn.Module):
     def __init__(self, config: _configs.ArchitectureConfig):
         super().__init__()
 
-        self.embed_tokens = nn.Embedding(
-            config.vocab_size, config.hidden_size, config.pad_token_id
-        )
-        self.layers = nn.ModuleList(
-            [DecoderLayer(config) for _ in range(config.num_hidden_layers)]
-        )
-        self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, config.pad_token_id)
+        self.layers = nn.ModuleList([DecoderLayer(config) for _ in range(config.num_hidden_layers)])
+        self.norm = RMSNorm(config.hidden_size, config)
         self.rotary_emb = initialize_rope(config)
 
     def forward(
@@ -42,9 +38,7 @@ class TextModel(nn.Module):
         )
 
         present_key_values = []
-        for layer, past_key_value in zip(
-            self.layers, past_key_values or [None] * len(self.layers)
-        ):
+        for layer, past_key_value in zip(self.layers, past_key_values or [None] * len(self.layers)):
             hidden_states, present_key_value = layer(
                 hidden_states=hidden_states,
                 attention_bias=attention_bias,

--- a/src/torch_onnx_models/components/_rms_norm.py
+++ b/src/torch_onnx_models/components/_rms_norm.py
@@ -5,19 +5,28 @@ __all__ = ["RMSNorm"]
 import torch
 from torch import nn
 from torch_onnx_models.components._rms_norm_utils import apply_rms_norm
+from torch_onnx_models import _configs
 
 
 class RMSNorm(nn.Module):
-    def __init__(self, hidden_size: int, eps: float = 1e-6):
+    def __init__(self, hidden_size: int, config: _configs.ArchitectureConfig):
         super().__init__()
         # Mark: weights
         self.weight = nn.Parameter(torch.ones(hidden_size))
-        self.variance_epsilon = eps
+        self.variance_epsilon = config.rms_norm_eps
+        self.all_fp32 = config.rms_norm_all_fp32
+        self.offset = config.rms_norm_offset
 
-    def forward(self, hidden_states):
-        return apply_rms_norm(
-            x=hidden_states, weight=self.weight, eps=self.variance_epsilon
-        )
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        input_dtype = hidden_states.dtype
+        weight = self.weight
+        # it's okay to do these casts since redudant casts will be optimized away
+        if self.all_fp32:
+            hidden_states = hidden_states.float()
+            weight = weight.float()
+        if self.offset is not None:
+            weight = weight + self.offset
+        return apply_rms_norm(x=hidden_states, weight=weight, eps=self.variance_epsilon).to(input_dtype)
 
     def extra_repr(self):
         return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"

--- a/src/torch_onnx_models/models/__init__.py
+++ b/src/torch_onnx_models/models/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+__all__ = ["Gemma3CausalLMModel"]
+
+from torch_onnx_models.models.gemma3 import Gemma3CausalLMModel

--- a/src/torch_onnx_models/models/gemma3.py
+++ b/src/torch_onnx_models/models/gemma3.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import copy
+
+import torch
+from torch import nn
+
+from torch_onnx_models.components import apply_rms_norm, create_attention_bias, initialize_rope, Attention, MLP, RMSNorm
+from torch_onnx_models._configs import ArchitectureConfig
+
+
+class Gemma3DecoderLayer(nn.Module):
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = Attention(config)
+        self.mlp = MLP(config)
+        self.input_layernorm = RMSNorm(config.hidden_size, config)
+        self.post_attention_layernorm = RMSNorm(config.hidden_size, config)
+        self.pre_feedforward_layernorm = RMSNorm(config.hidden_size, config)
+        self.post_feedforward_layernorm = RMSNorm(config.hidden_size, config)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_bias: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        past_key_value: tuple[torch.Tensor, torch.Tensor] | None,
+    ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        attn_output, present_key_value = self.self_attn(
+            hidden_states=hidden_states,
+            attention_bias=attention_bias,
+            position_embeddings=position_embeddings,
+            past_key_value=past_key_value,
+        )
+        hidden_states = self.post_attention_layernorm(attn_output)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.pre_feedforward_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.post_feedforward_layernorm(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states, present_key_value
+
+
+class Gemma3TextModel(nn.Module):
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        # original model is in bf16 and the modeling code has this in bf16
+        # huggingface chose to keep the same modeling code and use the weight dtype
+        # but this would lead to different results if the weight is float32
+        # we chose to use a constant in bf16 to match the original model
+        # https://github.com/huggingface/transformers/pull/29402
+        # https://github.com/huggingface/transformers/issues/38702
+        self.embed_scale = torch.tensor(config.hidden_size**0.5, dtype=torch.bfloat16).item()
+
+        self.layers = nn.ModuleList([Gemma3DecoderLayer(config) for _ in range(config.num_hidden_layers)])
+        self.layer_types = config.layer_types
+        self.sliding_window = config.sliding_window
+
+        self.norm = RMSNorm(config.hidden_size, config)
+        self.rotary_emb = initialize_rope(config)
+        # make this better, even transformers does the same for now
+        config = copy.deepcopy(config)
+        config.rope_theta = config.rope_local_base_freq
+        config.rope_type = "default"
+        config.rope_scaling = None
+        self.rotary_emb_local = initialize_rope(config)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        position_ids: torch.Tensor,
+        past_key_values: list[tuple[torch.Tensor, torch.Tensor]] | None = None,
+    ) -> tuple[torch.Tensor, list[tuple[torch.Tensor, torch.Tensor]]]:
+        # embed tokens and positions
+        hidden_states = self.embed_tokens(input_ids) * self.embed_scale
+        position_embeddings_dict = {
+            "global": self.rotary_emb(position_ids),
+            "local": self.rotary_emb_local(position_ids),
+        }
+
+        # get the attention bias
+        attention_bias_dict = {
+            "global": create_attention_bias(
+                attention_mask=attention_mask, query_length=input_ids.shape[-1], dtype=hidden_states.dtype
+            ),
+            "local": create_attention_bias(
+                attention_mask=attention_mask,
+                query_length=input_ids.shape[-1],
+                dtype=hidden_states.dtype,
+                sliding_window=self.sliding_window,
+            ),
+        }
+
+        present_key_values = []
+        for layer, layer_type, past_key_value in zip(
+            self.layers, self.layer_types, past_key_values or [None] * len(self.layers)
+        ):
+            hidden_states, present_key_value = layer(
+                hidden_states=hidden_states,
+                attention_bias=attention_bias_dict[layer_type],
+                position_embeddings=position_embeddings_dict[layer_type],
+                past_key_value=past_key_value,
+            )
+            present_key_values.append(present_key_value)
+
+        hidden_states = self.norm(hidden_states)
+
+        return hidden_states, present_key_values
+
+
+class Gemma3CausalLMModel(nn.Module):
+    def __init__(self, config: ArchitectureConfig):
+        super().__init__()
+        self.model = Gemma3TextModel(config)
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        position_ids: torch.Tensor,
+        past_key_values: list[tuple[torch.Tensor, torch.Tensor]] | None = None,
+    ) -> tuple[torch.Tensor, list[tuple[torch.Tensor, torch.Tensor]]]:
+        hidden_states, present_key_values = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+        )
+        logits = self.lm_head(hidden_states)
+        return logits, present_key_values


### PR DESCRIPTION
Gemma3 text model is now supported:
- attention bias can be created with sliding window. 
- attention module has option for q and k norms
- rms norm can compute all operations in fp32 using casts
- gemma3 text model created using common components + custom decoder layer and model. We can generalize this architecture if other models have similar settings like hybrid global and local rope and attention.