### PR TITLE
Add phi3 model support

### DIFF
--- a/examples/export_llama.py
+++ b/examples/export_llama.py
@@ -6,6 +6,7 @@ models = {
     # "mistral-7b": "mistralai/Mistral-7B-Instruct-v0.3",
     # "gemma-3-1b": "google/gemma-3-1b-it",
     # "gemma-3-270m": "google/gemma-3-270m-it",
+    # "phi-3_5-mini": "microsoft/Phi-3.5-mini-instruct",
 }
 
 for name, model_id in models.items():

--- a/src/torch_onnx_models/components/__init__.py
+++ b/src/torch_onnx_models/components/__init__.py
@@ -2,7 +2,6 @@ __all__ = [
     "apply_rms_norm",
     "apply_rotary_pos_emb",
     "Attention",
-    "CausalLMModel",
     "create_attention_bias",
     "get_activation",
     "get_rotary_pos_emb",
@@ -15,7 +14,6 @@ from torch_onnx_models.components._attention import Attention
 from torch_onnx_models.components._attention_utils import create_attention_bias
 from torch_onnx_models.components._activations import get_activation
 from torch_onnx_models.components._mlp import MLP
-from torch_onnx_models.components._model import CausalLMModel
 from torch_onnx_models.components._rms_norm_utils import apply_rms_norm
 from torch_onnx_models.components._rms_norm import RMSNorm
 from torch_onnx_models.components._rotary_embedding_utils import (

--- a/src/torch_onnx_models/components/_rotary_embedding.py
+++ b/src/torch_onnx_models/components/_rotary_embedding.py
@@ -8,23 +8,22 @@ from torch import nn
 from torch_onnx_models import _configs
 from torch_onnx_models.components._rotary_embedding_utils import get_rotary_pos_emb
 
+# TODO(jambayk): consider partial rotary factor as well, required for phi-4 models
+
 
 def _get_default_inv_freq(config: _configs.ArchitectureConfig) -> torch.Tensor:
-    return 1.0 / (
-        config.rope_theta
-        ** (torch.arange(0, config.head_dim, 2, dtype=torch.float) / config.head_dim)
-    )
+    return 1.0 / (config.rope_theta ** (torch.arange(0, config.head_dim, 2, dtype=torch.float) / config.head_dim))
 
 
 def _get_cos_sin_cache(
-    max_position_embeddings: int, inv_freq: torch.Tensor
+    max_position_embeddings: int, inv_freq: torch.Tensor, attention_scaling: float = 1.0
 ) -> tuple[torch.Tensor, torch.Tensor]:
     # should we do max position embeddings or original max position embeddings?
     # some models like llama4 has 10 million
     pos = torch.arange(0, max_position_embeddings, dtype=torch.float)
     angles = torch.outer(pos, inv_freq)
     # probably need to cast the caches to the same dtype as the model
-    return torch.cos(angles), torch.sin(angles)
+    return torch.cos(angles) * attention_scaling, torch.sin(angles) * attention_scaling
 
 
 class BaseRope(nn.Module):
@@ -42,9 +41,7 @@ class DefaultRope(BaseRope):
 
         with torch._subclasses.fake_tensor.unset_fake_temporarily():
             inv_freq = _get_default_inv_freq(config)
-            cos_cache, sin_cache = _get_cos_sin_cache(
-                config.max_position_embeddings, inv_freq
-            )
+            cos_cache, sin_cache = _get_cos_sin_cache(config.max_position_embeddings, inv_freq)
             self._register_cos_sin_cache(cos_cache, sin_cache)
 
 
@@ -59,7 +56,7 @@ class Llama3Rope(BaseRope):
             factor = config.rope_scaling["factor"]
             low_freq_factor = config.rope_scaling["low_freq_factor"]
             high_freq_factor = config.rope_scaling["high_freq_factor"]
-            old_context_len = config.rope_scaling["original_max_position_embeddings"]
+            old_context_len = config.original_max_position_embeddings
 
             low_freq_wavelen = old_context_len / low_freq_factor
             high_freq_wavelen = old_context_len / high_freq_factor
@@ -67,27 +64,58 @@ class Llama3Rope(BaseRope):
             wavelen = 2 * math.pi / inv_freq
             # wavelen < high_freq_wavelen: do nothing
             # wavelen > low_freq_wavelen: divide by factor
-            inv_freq_llama = torch.where(
-                wavelen > low_freq_wavelen, inv_freq / factor, inv_freq
-            )
+            inv_freq_llama = torch.where(wavelen > low_freq_wavelen, inv_freq / factor, inv_freq)
             # otherwise: interpolate between the two, using a smooth factor
-            smooth_factor = (old_context_len / wavelen - low_freq_factor) / (
-                high_freq_factor - low_freq_factor
-            )
-            smoothed_inv_freq = (
-                1 - smooth_factor
-            ) * inv_freq_llama / factor + smooth_factor * inv_freq_llama
-            is_medium_freq = ~(wavelen < high_freq_wavelen) * ~(
-                wavelen > low_freq_wavelen
-            )
-            inv_freq_llama = torch.where(
-                is_medium_freq, smoothed_inv_freq, inv_freq_llama
-            )
+            smooth_factor = (old_context_len / wavelen - low_freq_factor) / (high_freq_factor - low_freq_factor)
+            smoothed_inv_freq = (1 - smooth_factor) * inv_freq_llama / factor + smooth_factor * inv_freq_llama
+            is_medium_freq = ~(wavelen < high_freq_wavelen) * ~(wavelen > low_freq_wavelen)
+            inv_freq_llama = torch.where(is_medium_freq, smoothed_inv_freq, inv_freq_llama)
 
-            cos_cache, sin_cache = _get_cos_sin_cache(
-                config.max_position_embeddings, inv_freq_llama
-            )
+            cos_cache, sin_cache = _get_cos_sin_cache(config.max_position_embeddings, inv_freq_llama)
             self._register_cos_sin_cache(cos_cache, sin_cache)
+
+
+class LongRope(BaseRope):
+    def __init__(self, config: _configs.ArchitectureConfig):
+        super().__init__()
+
+        with torch._subclasses.fake_tensor.unset_fake_temporarily():
+            inv_freq = _get_default_inv_freq(config)
+
+            long_factor = torch.tensor(config.rope_scaling["long_factor"])
+            short_factor = torch.tensor(config.rope_scaling["short_factor"])
+
+            self.original_max_position_embeddings = (
+                config.original_max_position_embeddings or config.max_position_embeddings
+            )
+            factor = config.max_position_embeddings / self.original_max_position_embeddings
+            if factor <= 1.0:
+                attention_factor = 1.0
+            else:
+                attention_factor = math.sqrt(1 + math.log(factor) / math.log(self.original_max_position_embeddings))
+
+            # create short and long cache
+            # just to cover our bases, probably would never happen
+            self.has_long_cache = self.original_max_position_embeddings != config.max_position_embeddings
+            short_cos_cache, short_sin_cache = _get_cos_sin_cache(
+                self.original_max_position_embeddings, inv_freq / short_factor, attention_factor
+            )
+            if not self.has_long_cache:
+                self._register_cos_sin_cache(short_cos_cache, short_sin_cache)
+                return
+
+            long_cos_cache, long_sin_cache = _get_cos_sin_cache(
+                config.max_position_embeddings, inv_freq / long_factor, attention_factor
+            )
+            cos_cache = torch.cat([short_cos_cache, long_cos_cache], dim=0)
+            sin_cache = torch.cat([short_sin_cache, long_sin_cache], dim=0)
+            self._register_cos_sin_cache(cos_cache, sin_cache)
+
+    def forward(self, position_ids: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        if self.has_long_cache:
+            use_long_cache = (position_ids.max() >= self.original_max_position_embeddings).to(position_ids.dtype)
+            position_ids = position_ids + use_long_cache * self.original_max_position_embeddings
+        return get_rotary_pos_emb(position_ids, self.cos_cache, self.sin_cache)
 
 
 def initialize_rope(config: _configs.ArchitectureConfig) -> nn.Module:
@@ -95,5 +123,7 @@ def initialize_rope(config: _configs.ArchitectureConfig) -> nn.Module:
         return DefaultRope(config)
     if config.rope_type == "llama3":
         return Llama3Rope(config)
+    if config.rope_type == "longrope":
+        return LongRope(config)
 
     raise ValueError(f"Unsupported rope type: {config.rope_type}")

--- a/src/torch_onnx_models/models/__init__.py
+++ b/src/torch_onnx_models/models/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
-__all__ = ["Gemma3CausalLMModel"]
+__all__ = ["CausalLMModel", "Gemma3CausalLMModel", "Phi3CausalLMModel"]
 
+from torch_onnx_models.models.base import CausalLMModel
 from torch_onnx_models.models.gemma3 import Gemma3CausalLMModel
+from torch_onnx_models.models.phi3 import Phi3CausalLMModel

--- a/src/torch_onnx_models/models/phi3.py
+++ b/src/torch_onnx_models/models/phi3.py
@@ -1,0 +1,20 @@
+from torch_onnx_models.models.base import CausalLMModel
+
+
+class Phi3CausalLMModel(CausalLMModel):
+    def preprocess_weights(self, state_dict):
+        # not fully sure if we should split the qkv and gate_up projections here or just create a model class with unsplit projections
+        state_dict = super().preprocess_weights(state_dict)
+        q_size = self.config.num_attention_heads * self.config.head_dim
+        kv_size = self.config.num_key_value_heads * self.config.head_dim
+        for key in list(state_dict.keys()):
+            if "qkv_proj" in key:
+                state_dict[key.replace("qkv_proj", "q_proj")] = state_dict[key][:q_size]
+                state_dict[key.replace("qkv_proj", "k_proj")] = state_dict[key][q_size : q_size + kv_size]
+                state_dict[key.replace("qkv_proj", "v_proj")] = state_dict[key][q_size + kv_size :]
+                del state_dict[key]
+            elif "gate_up_proj" in key:
+                state_dict[key.replace("gate_up_proj", "gate_proj")] = state_dict[key][: self.config.intermediate_size]
+                state_dict[key.replace("gate_up_proj", "up_proj")] = state_dict[key][self.config.intermediate_size :]
+                del state_dict[key]
+        return state_dict


### PR DESCRIPTION
- CausalLM model moved to `model.base`
- Gemma3CausalLM and Phi3CausalLM inherit from this common causal lm model architecture
- longrope initialization. instead of using a conditional on the max position ids to branch, we instead use it to offset the position ids to the desired short or long cache.
- models now have an optional method called preprocess_weights